### PR TITLE
Fix the endpoints names now data.gov.uk is nearly fixed

### DIFF
--- a/mash_health/models.py
+++ b/mash_health/models.py
@@ -11,10 +11,8 @@ class Healthcare(object):
 
     @cache.memoize(timeout=86400)
     def find_by_name(self, service, name):
-        if service == 'pharmacies':
-            url = '{0}/{1}/name?organisation_name={2}'
-        else:
-            url = '{0}/{1}/organisation_name?organisation_name={2}'
+        url = '{0}/{1}/name?name={2}'
+
         response = requests.get(url.format(self.base_url, service, name))
         if response.status_code != requests.codes.ok:
             response.raise_for_status()

--- a/mash_health/templates/index.html
+++ b/mash_health/templates/index.html
@@ -22,9 +22,9 @@
             <div class="list-group-item">
               <h5 class="list-group-item-heading">{{data.result|length}} {{service}} {% if form.name.data %}named{% else %}in{% endif %} {{query}}</h5>
             </div>
-            {% for result in data.result|sort(attribute='organisation_name') %}
+            {% for result in data.result|sort(attribute='name') %}
             <div class="list-group-item" id="{{loop.index}}">
-              <p class="lead">{{result.organisation_name}}</p>
+              <p class="lead">{{result.name}}</p>
               <p><i class="fa fa-map-marker fa-fw fa-lg" aria-hidden="true"></i> {% if result.address1 %}{{result.address1}},{% endif %} {% if result.address2 %}{{result.address2}},{% endif%} {% if result.address3 %}{{result.address3}},{% endif %} {% if result.city %}{{result.city}},{% endif %} {% if result.county %}{{result.county}},{% endif %} {% if result.postcode %}{{result.postcode}}{% endif %}</p>
               {% if result.phone %}<p><i class="fa fa-phone fa-fw fa-lg" aria-hidden="true"></i> <a href="tel:{{result.phone}}">{{result.phone}}</a></p>{% endif %}
               {% if result.email %}<p style="word-wrap: break-word;"><i class="fa fa-envelope-o fa-fw fa-lg" aria-hidden="true"></i> <a href="mailto:{{result.email}}" target="_blank">{{result.email}}</a></p>{% endif %}
@@ -45,7 +45,7 @@
 
           {% if data %}
           {% for result in data.result %}
-          L.marker([{{result.latitude}}, {{result.longitude}}]).bindPopup("{{result.organisation_name}}").on('click', zoomToFeature).addTo(results);
+          L.marker([{{result.latitude}}, {{result.longitude}}]).bindPopup("{{result.name}}").on('click', zoomToFeature).addTo(results);
           {% endfor %}
           {% endif %}
 


### PR DESCRIPTION
The naming of the thing's name was inconsistent on data.gov.uk meaning
that checks had to be made whether to use name or organisation_name
based on type.  Now all endpoints will work with '/name?name='.

Probably should make sure the newly updated data.gov.uk API server is
deployed before deploying this.
